### PR TITLE
add option to set custom fallback directory

### DIFF
--- a/xcwd.c
+++ b/xcwd.c
@@ -216,28 +216,37 @@ static void cwdOfDeepestChild(processes_t p, long pid)
             return;
 }
 
-int getHomeDirectory()
+int getHomeDirectory(const char* HOME)
 {
     LOG("%s", "getenv $HOME...\n");
-    fprintf(stdout, "%s\n", getenv("HOME"));
+    fprintf(stdout, "%s\n", HOME);
     return EXIT_FAILURE;
 }
 
 int main(int argc, const char *argv[])
 {
-    (void)argc;
-    (void)argv;
+    char* HOME = NULL;
+    if (argc == 2) {
+      // we were explicitly passed a fallback directory
+      HOME = malloc(strlen(argv[1]));
+      strcpy(HOME, argv[1]);
+    }
+    else {
+      // not passed a fallback directory, use environment home
+      HOME = malloc(strlen(getenv("HOME")));
+      strcpy(HOME, getenv("HOME"));
+    }
 
     processes_t p;
     long pid;
     Window w = focusedWindow();
     if (w == 0)
-        return getHomeDirectory();
+        return getHomeDirectory(HOME);
 
     pid = windowPid(w);
     p = getProcesses();
     if(p == NULL)
-        return getHomeDirectory();
+        return getHomeDirectory(HOME);
     if (pid != -1) {
         qsort(p->ps, p->n, sizeof(struct proc_s), ppidCmp);
     }
@@ -268,10 +277,10 @@ int main(int argc, const char *argv[])
         cwdOfDeepestChild(p, pid);
     else {
         LOG("%s", "getenv $HOME...\n");
-        fprintf(stdout, "%s\n", getenv("HOME"));
+        fprintf(stdout, "%s\n", HOME);
     }
     freeProcesses(p);
-
+    free((char*)HOME);
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
This commit adds an option for the user to pass a parameter to xcwd that will be used as the fallback directory if it can't find the working directory of the focused window. If no parameter is passed, the $HOME environment variable is used like before.

This is useful for urxvtd/urxvtc, since the  "-cd" option passed to urxvtc is interpreted in the context of the daemon. This means that the $HOME environment variable for the daemon is most likely "/", which is probably not where new terminals should open. Invoking xcwd with a line like:
xcwd /home/USERNAMEHERE
prevents that from happening.
