### PR TITLE
fix duplicate slash in install dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC=gcc
 CFLAGS=-Wall -Wextra -std=gnu99 -O2
 LDFLAGS=-lX11
 EXE="xcwd"
-prefix=/usr/
+prefix=/usr
 UNAME:=$(shell uname)
 O=${CFILES:.c=.o}
 


### PR DESCRIPTION
There was an extra slash when combining the install dir prefix with the `bin` path, resulting in this output from the `make install`

```
install -m 0755 "xcwd" /usr//bin
```

Note the `//` between `usr` and `bin`.
